### PR TITLE
Fix facility list on login form

### DIFF
--- a/src/js/modules/login/route.js
+++ b/src/js/modules/login/route.js
@@ -5,12 +5,11 @@ const FacilitiesCollection = require("../../entities/facilities/collection");
 
 module.exports = Backbone.Blazer.Route.extend({
 	prepare(routeData) {
-		routeData.posts = new FacilitiesCollection();
-		routeData.f1 = routeData.posts.fetch();
-		return Promise.all([routeData.f1]);
+		routeData.facilities = new FacilitiesCollection();
+		return routeData.facilities.fetch();
 	},
 
-	execute(routeData) {	// doesn't get called till f1 and f2 are complete
-		Radio.request("root", "body", new LoginView());
+	execute({ facilities }) {
+		Radio.request("root", "body", new LoginView({ facilities }));
 	}
 });

--- a/src/js/modules/login/template.hbs
+++ b/src/js/modules/login/template.hbs
@@ -49,10 +49,6 @@
                 required=""
                 size="1" tabindex="-1" aria-hidden="true">
 
-
-
-
-
 {{#each facilities}}<option value={{_id}}>{{facilityName}}</option>{{/each}}
 
 

--- a/src/js/modules/login/view.js
+++ b/src/js/modules/login/view.js
@@ -4,10 +4,16 @@ module.exports = Marionette.View.extend({
 	className: "starter-template",
 	template: require("./template.hbs"),
     ui: {
-    modalxxx: "#myModal"
-  },
-  onAttach: function() {
-    this.ui.modalxxx.modal('show');
-  }
+		modalxxx: "#myModal"
+	},
 
+	templateContext() {
+		return {
+			facilities: this.getOption('facilities').toJSON(),
+		};
+	},
+
+	onAttach: function() {
+		this.ui.modalxxx.modal('show');
+	}
 });


### PR DESCRIPTION
Was pretty close, did a few things:

1. Cleaned up the `prepare()` on the route
2. Passed the fetched facilities collection into the login view (did not pass as a `model` or `collection` property, as it seems to be supplementary data, not the main data of the view)\
3. Serialized the facility collection in the context that gets passed to the template. If the collection had been passed to the view as the `collection`, this would have been done automatically.

[Here's some good information in the docs](http://marionettejs.com/docs/master/template.html#models-and-collections) regarding how the template context is assembled, from the view's `model` and `collection` as well as additional `templateContext` that you provide it