### PR TITLE
Require files relative to root to avoid errors on deep routes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,10 +6,10 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <title>VistA Surgery</title>
-        <link rel="stylesheet" href="./app.css" />
+        <link rel="stylesheet" href="/app.css" />
     </head>
     <body>
         <div id="app"></div>
-        <script src="./app.js" />
+        <script src="/app.js" />
     </body>
 </html>


### PR DESCRIPTION
Looks like the pushstate plugin was working as intended, but the script & style files were being required relative to the route instead of the root, so when you were in a route not at the root (ie `/about/`) it was trying to find the files at `/about/style.css`

Didn't look into browserSync yet, but figured this would at least do for now